### PR TITLE
[Fixed] Macro snippets

### DIFF
--- a/SNIPPETS.md
+++ b/SNIPPETS.md
@@ -103,7 +103,7 @@
 |xifw   |`if...with...`        |```{{#if(obj)}}{{#with(obj)}}//code{{/with}}{{/if}}```                |
 |xlif   |`elseif...`           |```{{elseif(x===1)}}//code```                                         |
 |xm     |`macro`               |```{{#macro('name',param)}}{{param}}{{/macro}}```                     |
-|xmc    |`macro call`          |```{{#macro('name','variable')}}```                                   |
+|xmc    |`macro call`          |```{{macro('name','variable')}}```                                   |
 |xrange |`range...`            |```range(0,3)```                                                      |
 |xroot  |`root`                |```{{root.name}}```                                                   |
 |xs     |`set`                 |```{{set(x=1)}}```                                                    |

--- a/SNIPPETS.md
+++ b/SNIPPETS.md
@@ -102,7 +102,7 @@
 |xiff   |`if...elseif...`      |```{{#if(x===1)}}//code{{elseif(x===2)}}//code{{else}}//code{{/if}}```|
 |xifw   |`if...with...`        |```{{#if(obj)}}{{#with(obj)}}//code{{/with}}{{/if}}```                |
 |xlif   |`elseif...`           |```{{elseif(x===1)}}//code```                                         |
-|xm     |`macro`               |```{{#macro('name',param)}}{{param}}{{/macro}}```                     |
+|xm     |`macro`               |```{{#macro('name','param')}}{{param}}{{/macro}}```                     |
 |xmc    |`macro call`          |```{{macro('name','variable')}}```                                   |
 |xrange |`range...`            |```range(0,3)```                                                      |
 |xroot  |`root`                |```{{root.name}}```                                                   |

--- a/Snippets/xtemplate/macro-call.sublime-snippet
+++ b/Snippets/xtemplate/macro-call.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-{{#macro('${1:name}',${2:'${3:variable}'})}}
+{{macro('${1:name}',${2:'${3:variable}'})}}
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>xmc</tabTrigger>

--- a/Snippets/xtemplate/macro.sublime-snippet
+++ b/Snippets/xtemplate/macro.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-{{#macro('${1:name}',${2:param})}}
+{{#macro('${1:name}','${2:param}')}}
 	{{${2:param}}}
 {{/macro}}
 ]]></content>


### PR DESCRIPTION
The parameter must be a string in the process of defining a macro
```xtpl
{{#macro('name','param')}}
  {{param}}
{{/macro}}
```
and macro call
```xtpl
{{macro('name','variable')}}
```

https://github.com/xtemplate/xtemplate/blob/master/docs/syntax.md#macro